### PR TITLE
[query-param] Add url query param for easy sharing (issue #10) 

### DIFF
--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -61,7 +61,28 @@ leafletUI.tileServer.overlay = L.tileLayer(leafletUI.tileServer.overlayUrl(),
 leafletUI.tileServer.layer.addTo(leafletUI.map);
 leafletUI.tileServer.overlay.addTo(leafletUI.map);
 
+leafletUI.tileServer.layer.setUrlHistory =
+  leafletUI.tileServer.overlay.setUrlHistory = function(url) {
+    this.setUrl(url);
+    var query = '?';
+    if (leafletUI.tileServer.layer._url) {
+      query += 'url=' + leafletUI.encodeURI(leafletUI.tileServer.layer._url);
+    }
+    if (leafletUI.tileServer.overlay._url) {
+      query += '&overlay=' + leafletUI.encodeURI(leafletUI.tileServer.overlay._url);
+    }
+    history.pushState(null, '', query + window.location.hash)
+  };
+
 leafletUI.URL_REGEX = /[&?]url=/;
+
+leafletUI.encodeURI = function(url) {
+  return url.indexOf('&') < 0 ? window.encodeURI(url) : btoa(url);
+};
+
+leafletUI.decodeURI = function(url) {
+  return url.startsWith('http') ? window.decodeURI(url) : atob(url);
+};
 
 var addTileServer = function(url) {
   var tileServer = leafletUI.tileServer.getServers();
@@ -119,12 +140,12 @@ function getUrlQueryParam() {
 }
 
 riot.compile(function() {
-  this.onload = function () {
+  this.onload = function() {
     var url = getUrlQueryParam();
-    if (url){
+    if (url) {
       try {
-        leafletUI.tileServer.layer.setUrl(url.startsWith('http') ? window.decodeURI(url) : atob(url));
-      } catch(e) {
+        leafletUI.tileServer.layer.setUrl(leafletUI.decodeURI(url));
+      } catch (e) {
         console.log(e);
       }
     }

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -61,6 +61,8 @@ leafletUI.tileServer.overlay = L.tileLayer(leafletUI.tileServer.overlayUrl(),
 leafletUI.tileServer.layer.addTo(leafletUI.map);
 leafletUI.tileServer.overlay.addTo(leafletUI.map);
 
+leafletUI.URL_REGEX = /[&?]url=/;
+
 var addTileServer = function(url) {
   var tileServer = leafletUI.tileServer.getServers();
   if (!tileServer || !tileServer instanceof Array) {
@@ -108,7 +110,7 @@ var changeTileServer = function(url) {
 
 function getUrlQueryParam() {
   var search = window.location.search;
-  if (search && search.indexOf('[?&]url=') < 0) {
+  if (leafletUI.URL_REGEX.test(search)) {
     var param = search.split(/[?&]/).find(function(param) {
       return param && /^url=/.test(param);
     });
@@ -118,15 +120,13 @@ function getUrlQueryParam() {
 
 riot.compile(function() {
   this.onload = function () {
-    if (window.location.search && window.location.search.indexOf('[?&]url=') < 0) {
-      var url = getUrlQueryParam();
-      if (url){
-        try {
-          leafletUI.tileServer.layer.setUrl(url.startsWith('http') ? window.decodeURI(url) : atob(url));
-        } catch(e) {
-          console.log(e);
-        }
-      } 
+    var url = getUrlQueryParam();
+    if (url){
+      try {
+        leafletUI.tileServer.layer.setUrl(url.startsWith('http') ? window.decodeURI(url) : atob(url));
+      } catch(e) {
+        console.log(e);
+      }
     }
     riot.mount('*');
   }

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -49,7 +49,7 @@ leafletUI.tileServer.overlayUrl = function() {
 };
 
 leafletUI.tileServer.opts = {
-  attribution: '&copy; <a href="https://github.com/Joxit">Joxit</a> and your tile server',
+  attribution: '&copy; <a href="https://joxit.github.io/">Joxit</a> and your tile server. <a href="https://joxit.github.io/tile-server-ui">tile-server-ui</a>.',
   maxZoom: 22,
 };
 leafletUI.tileServer.layer = L.tileLayer(leafletUI.tileServer.url(),
@@ -106,8 +106,28 @@ var changeTileServer = function(url) {
   localStorage.setItem('tileServer', JSON.stringify(tileServer));
 }
 
+function getUrlQueryParam() {
+  var search = window.location.search;
+  if (search && search.indexOf('[?&]url=') < 0) {
+    var param = search.split(/[?&]/).find(function(param) {
+      return param && /^url=/.test(param);
+    });
+    return param ? param.replace(/^url=/, '') : param;
+  }
+}
+
 riot.compile(function() {
   this.onload = function () {
+    if (window.location.search && window.location.search.indexOf('[?&]url=') < 0) {
+      var url = getUrlQueryParam();
+      if (url){
+        try {
+          leafletUI.tileServer.layer.setUrl(url.startsWith('http') ? window.decodeURI(url) : atob(url));
+        } catch(e) {
+          console.log(e);
+        }
+      } 
+    }
     riot.mount('*');
   }
 });

--- a/src/tags/add.tag
+++ b/src/tags/add.tag
@@ -45,7 +45,7 @@
       if (leafletUI.addTag.tileServerList.value && leafletUI.addTag.tileServerList.value.length > 0) {
         addTileServer(leafletUI.addTag.tileServerList.value);
         changeTileServer(leafletUI.addTag.tileServerList.value);
-        leafletUI.tileServer.layer.setUrl(leafletUI.addTag.tileServerList.value);
+        leafletUI.tileServer.layer.setUrlHistory(leafletUI.addTag.tileServerList.value);
         leafletUI.snackbar(leafletUI.addTag.tileServerList.value + ' has been set.', false);
       } else {
         leafletUI.snackbar('Nothing to set.', false);

--- a/src/tags/change.tag
+++ b/src/tags/change.tag
@@ -40,13 +40,13 @@
     leafletUI.changeTag.change = function () {
       var url = leafletUI.changeTag.tileServerList.value;
       changeTileServer(url);
-      leafletUI.tileServer.layer.setUrl(url);
+      leafletUI.tileServer.layer.setUrlHistory(url);
       leafletUI.changeTag.close();
     };
     leafletUI.changeTag.overlay = function () {
       var url = leafletUI.changeTag.tileServerList.value;
       localStorage.setItem('tileServerOverlay', JSON.stringify(url));
-      leafletUI.tileServer.overlay.setUrl(url);
+      leafletUI.tileServer.overlay.setUrlHistory(url);
       leafletUI.changeTag.close();
     }
     leafletUI.changeTag.show = function () {

--- a/src/tags/remove.tag
+++ b/src/tags/remove.tag
@@ -56,7 +56,7 @@
 
     leafletUI.removeTag.overlay = function () {
       localStorage.setItem('tileServerOverlay', '');
-      leafletUI.tileServer.overlay.setUrl('');
+      leafletUI.tileServer.overlay.setUrlHistory('');
     };
 
     this.on('updated', function () {


### PR DESCRIPTION
- [x]  load query param first
- [x] use base64 hash for complicated uri
- [x] update query param when we update tile-server

This will not update the local storage. I don't know if it's usefull or not.